### PR TITLE
Log all the start address of all called functions in the binary.

### DIFF
--- a/libs2eplugins/src/CMakeLists.txt
+++ b/libs2eplugins/src/CMakeLists.txt
@@ -23,6 +23,8 @@ PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_SOURCE_DIR}/s2e/Plug
 add_library(
     s2eplugins
 
+    s2e/Plugins/FunctionCallLogger.cpp
+
     s2e/Plugins/ConstraintsDumper.cpp
 
     # Core plugins

--- a/libs2eplugins/src/s2e/Plugins/FunctionCallLogger.cpp
+++ b/libs2eplugins/src/s2e/Plugins/FunctionCallLogger.cpp
@@ -1,0 +1,108 @@
+///
+/// Copyright (C) 2024, Yongheng Chen
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+///
+
+#include <s2e/S2E.h>
+#include <s2e/ConfigFile.h>
+
+#include "FunctionCallLogger.h"
+
+namespace s2e {
+namespace plugins {
+
+namespace {
+
+//
+// This class can optionally be used to store per-state plugin data.
+//
+// Use it as follows:
+// void FunctionCallLogger::onEvent(S2EExecutionState *state, ...) {
+//     DECLARE_PLUGINSTATE(FunctionCallLoggerState, state);
+//     plgState->...
+// }
+//
+class FunctionCallLoggerState: public PluginState {
+    // Declare any methods and fields you need here
+
+public:
+    static PluginState *factory(Plugin *p, S2EExecutionState *s) {
+        return new FunctionCallLoggerState();
+    }
+
+    virtual ~FunctionCallLoggerState() {
+        // Destroy any object if needed
+    }
+
+    virtual FunctionCallLoggerState *clone() const {
+        return new FunctionCallLoggerState(*this);
+    }
+};
+
+}
+
+S2E_DEFINE_PLUGIN(FunctionCallLogger, "Describe what the plugin does here", "", );
+
+void FunctionCallLogger::initialize() {
+    m_detector = s2e()->getPlugin<ModuleExecutionDetector>();
+    FunctionMonitor *monitor = s2e()->getPlugin<FunctionMonitor>();
+    monitor->onCall.connect(sigc::mem_fun(*this, &FunctionCallLogger::onCall));
+}
+
+void FunctionCallLogger::onCall(S2EExecutionState *state, const ModuleDescriptorConstPtr &source,
+                     const ModuleDescriptorConstPtr &dest, uint64_t callerPc, uint64_t calleePc,
+                     const FunctionMonitor::ReturnSignalPtr &returnSignal) {
+    auto module = m_detector->getCurrentDescriptor(state);
+    if (!module) {
+        // Not in the binary.
+        return;
+    }
+    getDebugStream(state) << "Calling function: " << hexval(state->regs()->getPc()) << "\n";
+}
+
+
+void FunctionCallLogger::handleOpcodeInvocation(S2EExecutionState *state, uint64_t guestDataPtr, uint64_t guestDataSize)
+{
+    S2E_FUNCTIONCALLLOGGER_COMMAND command;
+
+    if (guestDataSize != sizeof(command)) {
+        getWarningsStream(state) << "mismatched S2E_FUNCTIONCALLLOGGER_COMMAND size\n";
+        return;
+    }
+
+    if (!state->mem()->read(guestDataPtr, &command, guestDataSize)) {
+        getWarningsStream(state) << "could not read transmitted data\n";
+        return;
+    }
+
+    switch (command.Command) {
+        // TODO: add custom commands here
+        case COMMAND_1:
+            break;
+        default:
+            getWarningsStream(state) << "Unknown command " << command.Command << "\n";
+            break;
+    }
+}
+
+
+
+} // namespace plugins
+} // namespace s2e

--- a/libs2eplugins/src/s2e/Plugins/FunctionCallLogger.h
+++ b/libs2eplugins/src/s2e/Plugins/FunctionCallLogger.h
@@ -1,0 +1,77 @@
+///
+/// Copyright (C) 2024, Yongheng Chen
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+///
+
+#ifndef S2E_PLUGINS_FUNCTIONCALLLOGGER_H
+#define S2E_PLUGINS_FUNCTIONCALLLOGGER_H
+
+#include <s2e/Plugin.h>
+
+#include <s2e/Plugins/Core/BaseInstructions.h>
+#include <s2e/Plugins/ExecutionMonitors/FunctionMonitor.h>
+#include <s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.h>
+
+
+namespace s2e {
+namespace plugins {
+
+
+enum S2E_FUNCTIONCALLLOGGER_COMMANDS {
+    // TODO: customize list of commands here
+    COMMAND_1
+};
+
+struct S2E_FUNCTIONCALLLOGGER_COMMAND {
+    S2E_FUNCTIONCALLLOGGER_COMMANDS Command;
+    union {
+        // Command parameters go here
+        uint64_t param;
+    };
+};
+
+
+
+class FunctionCallLogger : public Plugin, public IPluginInvoker {
+
+    S2E_PLUGIN
+public:
+    FunctionCallLogger(S2E *s2e) : Plugin(s2e) {
+    }
+
+    void initialize();
+
+    void onCall(S2EExecutionState *state, const ModuleDescriptorConstPtr &source,
+                        const ModuleDescriptorConstPtr &dest, uint64_t callerPc, uint64_t calleePc,
+                        const FunctionMonitor::ReturnSignalPtr &returnSignal);
+
+private:
+
+    ModuleExecutionDetector *m_detector;
+
+    // Allow the guest to communicate with this plugin using s2e_invoke_plugin
+    virtual void handleOpcodeInvocation(S2EExecutionState *state, uint64_t guestDataPtr, uint64_t guestDataSize);
+
+};
+
+} // namespace plugins
+} // namespace s2e
+
+#endif // S2E_PLUGINS_FUNCTIONCALLLOGGER_H

--- a/testsuite/state-with-complex-constraint/fix-config.sh
+++ b/testsuite/state-with-complex-constraint/fix-config.sh
@@ -17,4 +17,7 @@ pluginsConfig.ConstraintsDumper = {
     enable = true,
 }
 
+add_plugin("FunctionMonitor")
+add_plugin("FunctionCallLogger")
+
 EOF

--- a/testsuite/state-with-complex-constraint/main.c
+++ b/testsuite/state-with-complex-constraint/main.c
@@ -20,6 +20,8 @@
 
 #include <s2e/s2e.h>
 #include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
 
 const uint64_t FNV_PRIME = 1099511628211ULL;
 const uint64_t FNV_OFFSET_BASIS = 14695981039346656037ULL;
@@ -39,7 +41,9 @@ static void test_fork_simple(void) {
     char buffer[0x10];
     int sym_int = 0;
     s2e_make_symbolic(&sym_int, sizeof(int), "varne0");
-
+    
+    printf("This is a test for calling printf");
+    malloc(0x123);
     // Each of the two states should fork twice here,
     // resulting in a total of four states.
     if((sym_int & 0x1223) > 0) {


### PR DESCRIPTION
To use it, enable the following plugin:
```
add_plugin("FunctionMonitor")
add_plugin("FunctionCallLogger")
```